### PR TITLE
Fix prep_unit for fahrenheit

### DIFF
--- a/src/modules/params.rs
+++ b/src/modules/params.rs
@@ -47,7 +47,7 @@ async fn prep_address(args_address: String, config: &Config) -> Result<String> {
 }
 
 fn prep_unit(args_unit: String, config_unit: Option<&String>) -> Result<String> {
-	let unit = if !args_unit.is_empty() && config_unit.is_some() {
+	let unit = if args_unit.is_empty() && config_unit.is_some() {
 		match config_unit {
 			unit if unit == Some(&"°F".to_string()) => "fahrenheit",
 			_ => "celsius",


### PR DESCRIPTION
The --unit flag doesn't get checked correctly so you can't set the unit to fahrenheit. This is because the original code checks if that arg is *not* empty when if should be checking if it's empty.

Also, it may be helpful to use an enum, rather than passing strings around. I believe it will make the code clearer on what is being passed around and if you need to make changes to how temperatures are displayed, you only have to change a method on said enum, rather than finding/modifying it in different functions.