### PR TITLE
Fixed Fahrenheit config option not being detected

### DIFF
--- a/src/modules/args.rs
+++ b/src/modules/args.rs
@@ -8,8 +8,8 @@ pub struct Args {
 	pub address: Option<String>,
 
 	/// Unit of measurement ['c' (°Celsius) | 'f' (°Fahrenheit)]
-	#[clap(short, long, value_parser, default_value_t = String::new())]
-	pub unit: String,
+	#[clap(short, long, value_parser)]
+	pub unit: Option<String>,
 
 	/// Include the forecast for one week
 	#[clap(short, long, value_parser, action)]

--- a/src/modules/args.rs
+++ b/src/modules/args.rs
@@ -8,7 +8,7 @@ pub struct Args {
 	pub address: Option<String>,
 
 	/// Unit of measurement ['c' (°Celsius) | 'f' (°Fahrenheit)]
-	#[clap(short, long, value_parser, default_value_t = String::from("c"))]
+	#[clap(short, long, value_parser, default_value_t = String::new())]
 	pub unit: String,
 
 	/// Include the forecast for one week

--- a/src/modules/params.rs
+++ b/src/modules/params.rs
@@ -7,7 +7,10 @@ use crate::location::Geolocation;
 
 pub async fn get(args: &Args, config: &Config) -> Result<Config> {
 	let address = prep_address(args.address.as_deref().unwrap_or_default().to_string(), config).await?;
-	let unit = prep_unit(args.unit.to_string(), config.unit.as_ref())?;
+	let unit = prep_unit(
+		args.unit.as_deref().unwrap_or_default().to_string(),
+		config.unit.as_ref(),
+	)?;
 
 	Ok(Config {
 		address: Some(address),

--- a/src/modules/params.rs
+++ b/src/modules/params.rs
@@ -27,9 +27,7 @@ async fn prep_address(args_address: String, config: &Config) -> Result<String> {
 	{
 		if args_address.is_empty() {
 			let auto_location_prompt = Confirm::with_theme(&ColorfulTheme::default())
-				.with_prompt(
-					"You didn't specify a city. Should I check for a weather station close to your location?",
-				)
+				.with_prompt("You didn't specify a city. Should I check for a weather station close to your location?")
 				.interact()?;
 			if !auto_location_prompt {
 				std::process::exit(1);
@@ -49,7 +47,7 @@ async fn prep_address(args_address: String, config: &Config) -> Result<String> {
 fn prep_unit(args_unit: String, config_unit: Option<&String>) -> Result<String> {
 	let unit = if args_unit.is_empty() && config_unit.is_some() {
 		match config_unit {
-			unit if unit == Some(&"°F".to_string()) => "fahrenheit",
+			unit if unit == Some(&String::from("fahrenheit")) => "fahrenheit",
 			_ => "celsius",
 		}
 	} else if args_unit == "f" || args_unit == "fahrenheit" {


### PR DESCRIPTION
The default case for units in clap makes the check for units later return true even if no unit arguments were supplied. 