### PR TITLE
🐛 fix performance regression when translating from en to en

### DIFF
--- a/src/modules/display/forecast.rs
+++ b/src/modules/display/forecast.rs
@@ -160,7 +160,7 @@ impl Forecast {
 				)
 				.unwrap();
 
-			let date = if lang != "en_US" || lang != "en" {
+			let date = if !(lang == "en_US" || lang == "en") {
 				Locales::localize_date(dt, lang)?
 			} else {
 				dt.format("%a, %e %b").to_string()

--- a/src/modules/locales/localization.rs
+++ b/src/modules/locales/localization.rs
@@ -24,7 +24,7 @@ impl Locales {
 				match serde_json::from_str::<LocalesFile>(&file) {
 					Ok(contents) => contents.apply_to(&mut texts),
 					Err(_) => {
-						if lang != "en_US" || lang != "en" {
+						if !(lang == "en_US" || lang == "en") {
 							texts.translate_all(lang).await?;
 						}
 						return Ok(texts);
@@ -32,7 +32,7 @@ impl Locales {
 				};
 			}
 			Err(_) => {
-				if lang != "en_US" || lang != "en" {
+				if !(lang == "en_US" || lang == "en") {
 					texts.translate_all(lang).await?;
 				}
 			}


### PR DESCRIPTION
introduced in adca0602db76cb566f8df6895935ba8ec262e48a

Comparison logic was wrong, which caused the locale to be translated every time from English to English. Be advised that this means generating the translation is really slow, which is unaffected by this fix.

Fixes #62.