### PR TITLE
feat: add % chance of precipitation unit as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ If you are using GNU/Linux the location usually is `~/.config/weathercrab/wthrr.
         temperature: celsius, // Temperature units: `celsius` | `fahrenheit`
         speed: kmh, // (Wind)speed units: `kmh` | `mph` | `knots` | `ms`
         time: military, // Time Format: `military` | `ap_pm`
-        precipitation: mm, // Precipitation units: `mm` | `inch`
+        precipitation: probability, // Precipitation units: `probability` | `mm` | `inch`
     ),
     gui: (
         border: rounded, // Border style: `rounded` | `single` | `solid` | `double`

--- a/src/modules/args.rs
+++ b/src/modules/args.rs
@@ -12,7 +12,7 @@ pub struct Cli {
 	#[arg(long, short, use_value_delimiter = true, value_name = "FORECAST,...")]
 	pub forecast: Vec<Forecast>,
 
-	/// [e.g.: -u f,12h]
+	/// [e.g.: -u f,12h,in]
 	#[arg(long, short, use_value_delimiter = true, value_name = "UNIT,...")]
 	pub units: Vec<UnitArg>,
 
@@ -73,6 +73,8 @@ pub enum UnitArg {
 	AmPm,
 	#[value(name = "24h", alias = "military")]
 	Military,
+	#[value(name = "%", alias = "percent")]
+	Percent,
 	Mm,
 	#[value(name = "(in)ch", alias = "in")]
 	Inch,

--- a/src/modules/args.rs
+++ b/src/modules/args.rs
@@ -73,8 +73,8 @@ pub enum UnitArg {
 	AmPm,
 	#[value(name = "24h", alias = "military")]
 	Military,
-	#[value(name = "%", alias = "percent")]
-	Percent,
+	#[value(name = "%", alias = "probability")]
+	Probability,
 	Mm,
 	#[value(name = "(in)ch", alias = "in")]
 	Inch,

--- a/src/modules/display/current.rs
+++ b/src/modules/display/current.rs
@@ -257,6 +257,7 @@ impl Current {
 				current_hour,
 				night,
 				graph_opts,
+				units,
 				&t.weather_code,
 			)?),
 			_ => None,

--- a/src/modules/display/hourly.rs
+++ b/src/modules/display/hourly.rs
@@ -174,7 +174,7 @@ impl HourlyForecast {
 			temperatures = &weather.hourly.temperature_2m[..=24];
 			weather_codes = &weather.hourly.weathercode[..=24];
 			precipitation = match units.precipitation {
-				Precipitation::percent => {
+				Precipitation::probability => {
 					Self::prepare_precipitation_probability(&weather.hourly.precipitation_probability[..=24])?
 				}
 				_ => Self::prepare_precipitation(&weather.hourly.precipitation[..=24])?,
@@ -183,7 +183,7 @@ impl HourlyForecast {
 			temperatures = &weather.hourly.temperature_2m[25..=49];
 			weather_codes = &weather.hourly.weathercode[25..=49];
 			precipitation = match units.precipitation {
-				Precipitation::percent => {
+				Precipitation::probability => {
 					Self::prepare_precipitation_probability(&weather.hourly.precipitation_probability[..=24])?
 				}
 				_ => Self::prepare_precipitation(&weather.hourly.precipitation[25..=49])?,

--- a/src/modules/params/units.rs
+++ b/src/modules/params/units.rs
@@ -53,7 +53,7 @@ pub enum Time {
 #[allow(non_camel_case_types)]
 pub enum Precipitation {
 	#[default]
-	percent,
+	probability,
 	mm,
 	inch,
 }

--- a/src/modules/params/units.rs
+++ b/src/modules/params/units.rs
@@ -53,6 +53,7 @@ pub enum Time {
 #[allow(non_camel_case_types)]
 pub enum Precipitation {
 	#[default]
+	percent,
 	mm,
 	inch,
 }

--- a/src/modules/weather.rs
+++ b/src/modules/weather.rs
@@ -94,7 +94,7 @@ latitude={}
 			lon,
 			units.temperature.as_ref(),
 			units.speed.as_ref(),
-			if units.precipitation == Precipitation::percent { "mm" } else {units.precipitation.as_ref()},
+			if units.precipitation == Precipitation::probability { "mm" } else {units.precipitation.as_ref()},
 		);
 
 		let res = reqwest::get(url)

--- a/wthrr.ron
+++ b/wthrr.ron
@@ -12,7 +12,7 @@ Mac: /Users/<user>/Library/Application Support/weathercrab
         temperature: celsius, // Temperature units: `celsius` | `fahrenheit`
         speed: kmh, // (Wind)speed units: `kmh` | `mph` | `knots` | `ms`
         time: military, // Time Format: `military` | `ap_pm`
-        precipitation: mm, // Precipitation units: `mm` | `inch`
+        precipitation: probability, // Precipitation units: `probability` | `mm` | `inch`
     ),
     gui: (
         border: rounded, // Border style: `rounded` | `single` | `solid` | `double`


### PR DESCRIPTION
Implements probability of precipitation as configurable unit.

Since this is the most commonly used, it is set as the default.

closes #65