### PR TITLE
Fix config directory creation failure

### DIFF
--- a/src/modules/config.rs
+++ b/src/modules/config.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use colored::{Color::Yellow, Colorize};
 use directories::ProjectDirs;
 use optional_struct::*;
@@ -74,17 +75,18 @@ impl Config {
 		config
 	}
 
-	pub fn store(&self) {
+	pub fn store(&self) -> Result<()> {
 		let path = Self::get_path();
 
 		let cfg_dir = path.parent().unwrap();
 		if !cfg_dir.is_dir() {
-			fs::create_dir(cfg_dir).unwrap();
+			fs::create_dir_all(cfg_dir)?;
 		};
 
-		let mut file = File::create(path).unwrap();
+		let mut file = File::create(path)?;
 		let output = to_string_pretty(self, PrettyConfig::default()).unwrap();
-		file.write_all(output.as_bytes()).unwrap();
+		file.write_all(output.as_bytes())?;
+		Ok(())
 	}
 
 	pub fn get_path() -> PathBuf {

--- a/src/modules/params.rs
+++ b/src/modules/params.rs
@@ -86,7 +86,7 @@ impl Params {
 		} else {
 			// Handle explicit save call
 			self.config.apply_to(&mut config_file);
-			config_file.store();
+			config_file.store().context("Error saving config file.")?;
 			self.texts.store(&config_file.language);
 		}
 
@@ -118,7 +118,7 @@ impl Params {
 			_ => println!("{}", self.texts.config.no_selection),
 		}
 
-		self.config.store();
+		self.config.store().context("Error saving config file.")?;
 		self.texts.store(&self.config.language);
 
 		Ok(())


### PR DESCRIPTION
Fixes https://github.com/tobealive/wthrr-the-weathercrab/issues/81. `C:\Users\<user>\AppData\Roaming\weathercrab\` won't exist on first run so creating the `config` directory will fail.

File/folder creation/writes can legitimately fail due to file system issues (e.g. permissions) so I converted those calls to return `Result`'s instead of panic.