### PR TITLE
[Documentation] Add Information on `cargo install --git`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,4 +66,12 @@ cd wthrr-the-weathercrab
 cargo build --release
 ```
 
-When the build has finished, you'll find the `wthrr` binary inside the `./target/release` directory
+When the build has finished, you'll find the `wthrr` binary inside the `./target/release` directory.
+
+The same result is achieved by calling Cargo directly using the following
+command.  Cargo will execute the same steps in the background such that only one
+instruction needs to be executed.
+
+```bash
+cargo install --git https://github.com/tobealive/wthrr-the-weathercrab
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,28 +50,24 @@ There are several alternatives to `cargo install wthrr` from crates.io.
   ```
   nix run "github:tobealive/wthrr-the-weathercrab"
   ```
-- Use cargo to install the from souce
-  ```
-  cargo install --git  https://github.com/tobealive/wthrr-the-weathercrab.git `
-  ```
 
 ### Build from source
 
 Another way is to compile the app yourself.
-Assuming the rust toolchain is installed on your system, just clone the repo and build the release version.
+Assuming the Rust toolchain is installed,
 
-```
-git clone https://github.com/tobealive/wthrr-the-weathercrab.git
-cd wthrr-the-weathercrab
-cargo build --release
-```
+- use Cargo to install from the Git source;
 
-When the build has finished, you'll find the `wthrr` binary inside the `./target/release` directory.
+  ```bash
+  cargo install --git https://github.com/tobealive/wthrr-the-weathercrab
+  ```
 
-The same result is achieved by calling Cargo directly using the following
-command.  Cargo will execute the same steps in the background such that only one
-instruction needs to be executed.
+- or clone the repository and build the release version.
 
-```bash
-cargo install --git https://github.com/tobealive/wthrr-the-weathercrab
-```
+  ```bash
+  git clone https://github.com/tobealive/wthrr-the-weathercrab.git
+  cd wthrr-the-weathercrab
+  cargo build --release
+  ```
+
+When the build has finished, you will find the `wthrr` binary inside the `./target/release` directory.


### PR DESCRIPTION
This PR fixes #89 by adding a new paragraph to `INSTALL.md`.