### PR TITLE
♻️ refactor `get_forecast_indices()`

### DIFF
--- a/src/modules/display/product.rs
+++ b/src/modules/display/product.rs
@@ -5,7 +5,7 @@ use scopeguard::defer;
 use std::collections::HashMap;
 
 use crate::modules::{
-	forecast::get_indices,
+	forecast::get_forecast_indices,
 	params::Params,
 	weather::{OptionalWeather, Weather},
 };
@@ -42,7 +42,7 @@ impl Product<'_> {
 			return Ok(());
 		}
 
-		let forecast_indices = get_indices(&params.config.forecast);
+		let forecast_indices = get_forecast_indices(&params.config.forecast);
 
 		if forecast_indices.contains(&0) && forecast_indices.contains(&7) {
 			// Current day with hours & weekly overview

--- a/src/modules/forecast.rs
+++ b/src/modules/forecast.rs
@@ -16,19 +16,17 @@ fn get_indices(forecast: &HashSet<Forecast>, curr_day: Weekday) -> Vec<usize> {
 	// Until there is a more concise solution this is a working and fairly slim approach.
 	let mut forecast_indices: Vec<usize> = forecast
 		.iter()
-		.map(|val| {
-			match val {
-				Forecast::day => 0,
-				Forecast::week => 7,
-				Forecast::mo => get_day_index(days_from_ref_day, Weekday::Mon),
-				Forecast::tu => get_day_index(days_from_ref_day, Weekday::Tue),
-				Forecast::we => get_day_index(days_from_ref_day, Weekday::Wed),
-				Forecast::th => get_day_index(days_from_ref_day, Weekday::Thu),
-				Forecast::fr => get_day_index(days_from_ref_day, Weekday::Fri),
-				Forecast::sa => get_day_index(days_from_ref_day, Weekday::Sat),
-				Forecast::su => get_day_index(days_from_ref_day, Weekday::Sun),
-				Forecast::disable => 0, // or any default value you prefer
-			}
+		.map(|val| match val {
+			Forecast::day => 0,
+			Forecast::week => 7,
+			Forecast::mo => get_day_index(days_from_ref_day, Weekday::Mon),
+			Forecast::tu => get_day_index(days_from_ref_day, Weekday::Tue),
+			Forecast::we => get_day_index(days_from_ref_day, Weekday::Wed),
+			Forecast::th => get_day_index(days_from_ref_day, Weekday::Thu),
+			Forecast::fr => get_day_index(days_from_ref_day, Weekday::Fri),
+			Forecast::sa => get_day_index(days_from_ref_day, Weekday::Sat),
+			Forecast::su => get_day_index(days_from_ref_day, Weekday::Sun),
+			Forecast::disable => 0,
 		})
 		.collect();
 

--- a/src/modules/forecast.rs
+++ b/src/modules/forecast.rs
@@ -17,7 +17,6 @@ fn get_indices(forecast: &HashSet<Forecast>, curr_day: Weekday) -> Vec<usize> {
 	let mut forecast_indices: Vec<usize> = forecast
 		.iter()
 		.map(|val| match val {
-			Forecast::day => 0,
 			Forecast::week => 7,
 			Forecast::mo => get_day_index(days_from_ref_day, Weekday::Mon),
 			Forecast::tu => get_day_index(days_from_ref_day, Weekday::Tue),
@@ -26,7 +25,7 @@ fn get_indices(forecast: &HashSet<Forecast>, curr_day: Weekday) -> Vec<usize> {
 			Forecast::fr => get_day_index(days_from_ref_day, Weekday::Fri),
 			Forecast::sa => get_day_index(days_from_ref_day, Weekday::Sat),
 			Forecast::su => get_day_index(days_from_ref_day, Weekday::Sun),
-			Forecast::disable => 0,
+			_ => 0,
 		})
 		.collect();
 

--- a/src/modules/forecast.rs
+++ b/src/modules/forecast.rs
@@ -5,8 +5,7 @@ use std::collections::HashSet;
 use super::args::Forecast;
 
 pub fn get_forecast_indices(forecast: &HashSet<Forecast>) -> Vec<usize> {
-	let curr_day = Local::now().weekday();
-	get_indices(forecast, curr_day)
+	get_indices(forecast, Local::now().weekday())
 }
 
 fn get_indices(forecast: &HashSet<Forecast>, curr_day: Weekday) -> Vec<usize> {

--- a/src/modules/forecast.rs
+++ b/src/modules/forecast.rs
@@ -9,28 +9,28 @@ pub fn get_forecast_indices(forecast: &HashSet<Forecast>) -> Vec<usize> {
 }
 
 fn get_indices(forecast: &HashSet<Forecast>, curr_day: Weekday) -> Vec<usize> {
+	let days_from_ref_day = curr_day.number_from_monday();
+
 	// Indices for forecasts that should be rendered. 7 will be used as a special value
 	// [0] = current day; [1..7] = week days; [7] = week overview
 	// Until there is a more concise solution this is a working and fairly slim approach.
-	let mut forecast_indices: Vec<usize> = vec![];
-
-	let days_from_ref_day = curr_day.number_from_monday();
-
-	for val in forecast {
-		match val {
-			Forecast::day => forecast_indices.push(0),
-			Forecast::week => forecast_indices.push(7),
-			// Forecast weekdays
-			Forecast::mo => forecast_indices.push(get_day_index(days_from_ref_day, Weekday::Mon)),
-			Forecast::tu => forecast_indices.push(get_day_index(days_from_ref_day, Weekday::Tue)),
-			Forecast::we => forecast_indices.push(get_day_index(days_from_ref_day, Weekday::Wed)),
-			Forecast::th => forecast_indices.push(get_day_index(days_from_ref_day, Weekday::Thu)),
-			Forecast::fr => forecast_indices.push(get_day_index(days_from_ref_day, Weekday::Fri)),
-			Forecast::sa => forecast_indices.push(get_day_index(days_from_ref_day, Weekday::Sat)),
-			Forecast::su => forecast_indices.push(get_day_index(days_from_ref_day, Weekday::Sun)),
-			Forecast::disable => (),
-		}
-	}
+	let mut forecast_indices: Vec<usize> = forecast
+		.iter()
+		.map(|val| {
+			match val {
+				Forecast::day => 0,
+				Forecast::week => 7,
+				Forecast::mo => get_day_index(days_from_ref_day, Weekday::Mon),
+				Forecast::tu => get_day_index(days_from_ref_day, Weekday::Tue),
+				Forecast::we => get_day_index(days_from_ref_day, Weekday::Wed),
+				Forecast::th => get_day_index(days_from_ref_day, Weekday::Thu),
+				Forecast::fr => get_day_index(days_from_ref_day, Weekday::Fri),
+				Forecast::sa => get_day_index(days_from_ref_day, Weekday::Sat),
+				Forecast::su => get_day_index(days_from_ref_day, Weekday::Sun),
+				Forecast::disable => 0, // or any default value you prefer
+			}
+		})
+		.collect();
 
 	forecast_indices.sort();
 	forecast_indices


### PR DESCRIPTION
* Use a wrapper for the pub fn and pass current day as arg.
* Removes need to use `#[cfg(test)]` / `#[cfg(not(test))]` attrs to mock the current weekday to make it testable.
* Updates naming / comments.