### PR TITLE
Updated flake.nix to exclude network tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,13 @@
             rustPlatform.bindgenHook
           ];
           buildInputs = [openssl];
+
+          checkFlags = [
+            # connecting to internet does not work in the sandbox
+            "--skip=modules::location::tests::geolocation_response"
+            "--skip=modules::localization::tests::translate_string"
+          ];
+          
           meta = with lib; {
             license = licenses.mit;
             homepage = "https://github.com/tobealive/wthrr-the-weathercrab";


### PR DESCRIPTION
Resolves #115.

Disables `modules::localization::tests::translate_string` and `modules::location::tests::geolocation_response` when building.