### PR TITLE
[Enhancement] Less Ambiguous Wind Direction Arrows

### DIFF
--- a/src/modules/display/wind.rs
+++ b/src/modules/display/wind.rs
@@ -32,14 +32,14 @@ impl WindDirection {
 
 	pub const fn get_icon(&self) -> char {
 		match *self {
-			Self::N => '',
-			Self::NE => '',
-			Self::E => '',
-			Self::SE => '',
-			Self::S => '',
-			Self::SW => '',
-			Self::W => '',
-			Self::NW => '',
+			Self::N => '↓',
+			Self::NE => '↙',
+			Self::E => '←',
+			Self::SE => '↖',
+			Self::S => '↑',
+			Self::SW => '↗',
+			Self::W => '→',
+			Self::NW => '↘',
 		}
 	}
 }


### PR DESCRIPTION
This PR is related to #121 and applies less ambiguous wind direction arrows.  Despite also having emojis for arrows, there are furthermore some characters available which are natural part of the default keyboard layouts of Linux systems.  These arrows are known to be less ambiguous than the emoji arrows, which are sometimes rendered as Asian characters, due to having lower UTF-8 character codes.

(Drafted due to the typo in the commit message:  "ambigous".)