### PR TITLE
[Enhancement] Remove GitHub Caching Action

### DIFF
--- a/.github/workflows/tarpaulin.yml
+++ b/.github/workflows/tarpaulin.yml
@@ -2,12 +2,6 @@ name: tarpaulin
 
 on:
   pull_request:
-    paths:
-      - Cargo.lock
-      - Cargo.toml
-      - src/*.rs
-      - src/**/*.rs
-      - src/**/**/*.rs
 
 permissions:
   contents: read
@@ -18,31 +12,21 @@ jobs:
     name: coverage
     runs-on: ubuntu-latest
     steps:
+      - name: cargo
+        uses: taiki-e/install-action@v2.8.0
+        with:
+          tool: cargo-tarpaulin
+
       - name: python
         uses: actions/setup-python@v4.6.0
         with:
           python-version: 3.11
 
       - name: checkout
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
         with:
           persist-credentials: false
           ref: ${{ github.head_ref }}
-
-      - name: cache
-        uses: actions/cache@v3.3.1
-        with:
-          key: ${{ runner.os }}-tarpaulin-${{ github.sha }}
-          path: |
-            ~/.cargo/bin/cargo-tarpaulin
-          restore-keys: |
-            ${{ runner.os }}-tarpaulin-
-
-      - name: cargo
-        run: |
-          if [[ ! -e ~/.cargo/bin/cargo-tarpaulin ]]; then
-            cargo install cargo-tarpaulin;
-          fi
 
       - name: requirements
         run: echo pycobertura >> requirements.txt


### PR DESCRIPTION
This PR allows for faster code coverage determination due to the omission of the GitHub Caching Action.  Tarpaulin is now fetched directly as binary from its project.  This saves about three minutes.  Thus, I decided to suggest to running the code coverage determination always, i.e. on each PR.