### PR TITLE
[Enhancement] Add Forecast for Tomorrow

### DIFF
--- a/src/modules/args.rs
+++ b/src/modules/args.rs
@@ -57,6 +57,8 @@ pub enum Forecast {
 	sa,
 	#[value(aliases = ["sun", "sunday"])]
 	su,
+	#[value(name = "(t)omorrow", aliases = ["t", "to", "tom"])]
+	tomorrow,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, AsRefStr, Serialize, Deserialize)]

--- a/src/modules/forecast.rs
+++ b/src/modules/forecast.rs
@@ -25,6 +25,7 @@ fn get_indices(forecast: &HashSet<Forecast>, curr_day: Weekday) -> Vec<usize> {
 			Forecast::fr => get_day_index(dist_from_ref_day, Weekday::Fri),
 			Forecast::sa => get_day_index(dist_from_ref_day, Weekday::Sat),
 			Forecast::su => get_day_index(dist_from_ref_day, Weekday::Sun),
+			Forecast::tomorrow => get_day_index(dist_from_ref_day, Local::now().weekday().succ()),
 			_ => 0,
 		})
 		.collect();


### PR DESCRIPTION
This PR aims to fix #132 by providing a new CLI option to ask for "tomorrow".

Examples:

- `wthrr London -f t`
- `wthrr London -f to`
- `wthrr London -f tom`
- `wthrr London -f tomorrow`

The possible values are oriented on the current implementations; users are always allowed to spell out the whole names of the (week) days as well as to abbreviate it by one, two, or three (initial) letters.