### PR TITLE
[Bugfix] Enable `wthrr -f tomorrow`

### DIFF
--- a/src/modules/args.rs
+++ b/src/modules/args.rs
@@ -57,7 +57,7 @@ pub enum Forecast {
 	sa,
 	#[value(aliases = ["sun", "sunday"])]
 	su,
-	#[value(name = "(t)omorrow", aliases = ["t", "to", "tom"])]
+	#[value(name = "(t)omorrow", aliases = ["t", "to", "tom", "tomorrow"])]
 	tomorrow,
 }
 


### PR DESCRIPTION
This PR fixes a minor bug due to which `wthrr -f tomorrow` led to an error; "tip: a similar value exists: '(t)omorrow'".

When I defined the query for the succeeding day, I forgot to add the word itself as an allowed alias value.  The command still works as it should, so this is not a critical bug.  But I would like to correct my mistake now that I noticed it.

I am sorry.