### PR TITLE
:bug: fix crash of Tarpaulin workflow

### DIFF
--- a/.github/workflows/tarpaulin.yml
+++ b/.github/workflows/tarpaulin.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: requirements
         run: echo pycobertura >> requirements.txt


### PR DESCRIPTION
So far, the Tarpaulin workflow always crashed when a PR from a fork was raised against this repository.  This change shall fix this problem.