### PR TITLE
:bug: remove commit message settings in `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       time: "04:00"
     assignees:
       - tobealive
-    commit-message:
-      prefix: "⬆️ "
 
   - package-ecosystem: github-actions
     directory: /
@@ -17,5 +15,3 @@ updates:
       time: "04:00"
     assignees:
       - tobealive
-    commit-message:
-      prefix: "⬆️ "


### PR DESCRIPTION
These are the changes I mentioned in #143.

If you make your way through the definitions of the functions called in https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb#L62-L73, you will see that we should achieve the desired effect without the explicit prefix, as well.