### PR TITLE
:robot: change default assignee for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: weekly
       time: "04:00"
     assignees:
-      - tobealive
+      - kevinmatthes
 
   - package-ecosystem: github-actions
     directory: /
@@ -14,4 +14,4 @@ updates:
       interval: weekly
       time: "04:00"
     assignees:
-      - tobealive
+      - kevinmatthes


### PR DESCRIPTION
Because I will take care about the version updates suggested by Dependabot from now on, I made me the default assignee of its PRs.  This is also how you adjusted the list of assignees for #152 and #153 manually, @tobealive.