### PR TITLE
refactor: use `LazyLock` for the config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(lazy_cell)]
 #![deny(
 	clippy::semicolon_if_nothing_returned,
 	clippy::wildcard_imports,
@@ -18,18 +19,15 @@ mod modules;
 use anyhow::Result;
 use clap::Parser;
 
-use modules::{
-	args::Cli, config::Config, display::product::Product, location::Location, params::Params, weather::Weather,
-};
+use modules::{args::Cli, display::product::Product, location::Location, params::Params, weather::Weather};
 
 #[tokio::main]
 async fn main() -> Result<()> {
 	let args = Cli::parse();
-	let config = Config::get();
-	let params = Params::merge(&config, &args).await?;
+	let params = Params::eval(&args).await?;
 
 	run(&params).await?.render(&params)?;
-	params.handle_next(args, config)?;
+	params.handle_next(args)?;
 
 	Ok(())
 }

--- a/src/modules/params.rs
+++ b/src/modules/params.rs
@@ -7,7 +7,7 @@ use optional_struct::Applyable;
 
 use super::{
 	args::{Cli, Forecast},
-	config::Config,
+	config::{Config, CONFIG},
 	localization::{ConfigLocales, Locales},
 	location::Location,
 	units::Units,
@@ -21,7 +21,9 @@ pub struct Params {
 }
 
 impl Params {
-	pub async fn merge(config: &Config, args: &Cli) -> Result<Self> {
+	pub async fn eval(args: &Cli) -> Result<Self> {
+		let config = &CONFIG;
+
 		let language = match &args.language {
 			Some(lang) => lang.to_string(),
 			None => config.language.clone(),
@@ -69,7 +71,8 @@ impl Params {
 		})
 	}
 
-	pub fn handle_next(mut self, args: Cli, mut config_file: Config) -> Result<()> {
+	pub fn handle_next(mut self, args: Cli) -> Result<()> {
+		let mut config_file = CONFIG.clone();
 		if !args.save && !config_file.address.is_empty() {
 			return Ok(());
 		}
@@ -129,9 +132,8 @@ impl Params {
 			.interact()?;
 
 		if confirmation {
-			let path = Config::get_path();
-
-			std::fs::remove_dir_all(path.parent().unwrap()).with_context(|| "Error resetting config file.")?;
+			std::fs::remove_dir_all(Config::path().parent().unwrap())
+				.with_context(|| "Error resetting config file.")?;
 		}
 
 		Ok(())


### PR DESCRIPTION
LazyLock makes it into std lib with the upcoming release.

Generally, this adds a nice way to handle the config of an application, I think.

Edit:
The current solution might be sufficient as the config is handled pretty early already and evaluated with the args into the parameters of a run. It's not like it is heavily coupled and needs to be passed around as additional argument.
The draft atm adds a clone of the config struct. It should be possible to solve it using a lazy locked mutex.