### PR TITLE
🤖 call actionlint Docker image directly

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,9 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - uses: devops-actions/actionlint@v0.1.1
+      - uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color


### PR DESCRIPTION
This PR reduces the maintenance effort for the GHA workflow linter by calling its Docker image directly with the version being set to `latest` instead of applying the wrapper around it.

@tobealive, if you prefer to install updates for the linter by merging PRs, we might need to switch to Renovate as this dependency type is not recognised by Dependabot, as far as I know.